### PR TITLE
reversed throttle output in oi, gets wrong direction

### DIFF
--- a/src/main/kotlin/frc/robot/OI.kt
+++ b/src/main/kotlin/frc/robot/OI.kt
@@ -12,6 +12,6 @@ class OI(private val joystick: Joystick){
     }
 
     fun getSlider(): Double {
-        return joystick.throttle
+        return -joystick.throttle
     }
 }


### PR DESCRIPTION
Literally just added a minus sign.